### PR TITLE
Refactor input handling and harden add-flow logic

### DIFF
--- a/SB_Database_Project/Super_Bowl_Database_Mini_Project/AddSuperBowl.java
+++ b/SB_Database_Project/Super_Bowl_Database_Mini_Project/AddSuperBowl.java
@@ -2,6 +2,7 @@ import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.time.Year;
 import java.util.Arrays;
 import java.util.Scanner;
 
@@ -29,9 +30,6 @@ public class AddSuperBowl {
 	// scanner that gathers the user's input
 	static Scanner userInput = new Scanner(System.in);
 	
-	// writer to write out the added information into the file
-	static BufferedWriter writer;
-	
 	
 	/**
 	 * 
@@ -43,41 +41,27 @@ public class AddSuperBowl {
 	
 	public static void addInfo() throws IOException
 	{
-		
-		
-		try {
-            writer = new BufferedWriter(new FileWriter(sbInfoFile, true));
-        } catch (IOException e) {
-            System.out.println("Error: " + e.getMessage());
-            return;
-        }
-		
 		System.out.println("Would you like to add information of a new Super Bowl? (Y or N)");
-		String response = userInput.next();
-		
-		
-		if(!(response.equalsIgnoreCase("N")) && !(response.equalsIgnoreCase("Y")))
+		String response = readYesNo();
+
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(sbInfoFile, true)))
 		{
-			System.out.println("Enter Y for yes or N for no please.");
-			response = userInput.next();
-		}
-		
-		while(!(response.equalsIgnoreCase("N")))
-		{
-			setInputs();
-			
-			writer.newLine();
-			writer.write(inputs[0]);
-			
-			for(int i = 1; i < inputs.length; i++)
+			while(!(response.equalsIgnoreCase("N")))
 			{
-				writer.write(", " + inputs[i]);
+				setInputs();
+				
+				writer.newLine();
+				writer.write(inputs[0]);
+				
+				for(int i = 1; i < inputs.length; i++)
+				{
+					writer.write(", " + inputs[i]);
+				}
 				writer.flush();
+				
+				System.out.println("Would you like to add another Super Bowl? (Y or N)");
+				response = readYesNo();
 			}
-			
-			
-			System.out.println("Would you like to add another Super Bowl? (Y or N)");
-			response = userInput.next();
 		}
 		
 		
@@ -111,14 +95,14 @@ public class AddSuperBowl {
 	public static void setSBNumber()
 	{
 		System.out.println("Enter the number of the Super Bowl (using decimal numbers): ");
-		int sbNumber = userInput.nextInt();
+		int sbNumber = readInt();
 		
 		// While loops ensures that the user will enter a valid super bowl number that has not been already played
 		// or that is an impossible. It will stay in the while loop until the user inputs a valid number.
 		while(sbNumber < 58)
 		{
 			System.out.println("That is not a valid input, please try again.");
-			sbNumber = userInput.nextInt();
+			sbNumber = readInt();
 		}
 		
 		inputs[0] = roman_to_integer.convertToRoman(sbNumber);
@@ -144,7 +128,7 @@ public class AddSuperBowl {
 		}
 		
 		System.out.println("Enter the home team: ");
-		String homeTeam = userInput.next();
+		String homeTeam = userInput.next().trim();
 		
 		// Array of teams is sorted to properly perform the binary search in the following while loops
 		Arrays.sort(allTeams);
@@ -154,18 +138,18 @@ public class AddSuperBowl {
 		while(Arrays.binarySearch(allTeams, homeTeam) < 0)
 		{
 			System.out.println("That is not a valid input, please try again.");
-			homeTeam = userInput.next();
+			homeTeam = userInput.next().trim();
 		}
 		
 		System.out.println("Enter the away team: ");
-		String awayTeam = userInput.next();
+		String awayTeam = userInput.next().trim();
 		
 		// while loop ensures that the input is a team and that they are not entering the same twice and
 		// stays in the while loop until the user's input is valid to it's constraints
 		while(Arrays.binarySearch(allTeams, awayTeam) < 0 || awayTeam.equalsIgnoreCase(homeTeam))
 		{
 			System.out.println("That is not a valid input, please try again.");
-			awayTeam = userInput.next();
+			awayTeam = userInput.next().trim();
 		}
 		
 		
@@ -180,10 +164,10 @@ public class AddSuperBowl {
 	public static void setScore()
 	{
 		System.out.println("Enter the winning score: ");
-		int winner = userInput.nextInt();
+		int winner = readInt();
 		
 		System.out.println("Enter the losing score: ");
-		int loser = userInput.nextInt();
+		int loser = readInt();
 		
 		// Switches the value of the winner and loser if the losing score is set to be higher that the winning score
 		if(loser > winner)
@@ -203,17 +187,17 @@ public class AddSuperBowl {
 	public static void setWinner()
 	{
 		System.out.println("Enter the name of the winning team: ");
-		String winner = userInput.next();
+		String winner = userInput.next().trim();
 		
 		// Array of the 2 teams that the user previously entered, used for making sure the user enters a team that played
 		String[] playingTeams = inputs[1].split(" vs. ");
 		
 		// while loop ensures that the user enters one of the 2 teams that played in the super bowl they are adding and
 		// stays in the while loop until the user's input is valid
-		while(Arrays.binarySearch(playingTeams, winner) < 0)
+		while(!(winner.equalsIgnoreCase(playingTeams[0]) || winner.equalsIgnoreCase(playingTeams[1])))
 		{
 			System.out.println("That is not a valid input, please try again.");
-			winner = userInput.next();
+			winner = userInput.next().trim();
 		}
 		
 		inputs[3] = winner;
@@ -227,7 +211,7 @@ public class AddSuperBowl {
 	public static void setMVP()
 	{
 		System.out.println("Enter the name of the player than won the MVP: ");
-		inputs[4] = userInput.next();
+		inputs[4] = readNonEmptyLine();
 	}
 	
 	/**
@@ -238,14 +222,17 @@ public class AddSuperBowl {
 	public static void setYear()
 	{
 		System.out.println("Enter the year the game was played: ");
-		int year = userInput.nextInt(); 
+		int year = readInt(); 
+		int minYear = getMinimumNewYear();
+		int maxYear = Year.now().getValue() + 1;
 		
 		// While loop ensures the user enters a year after the most recently played Super Bowl and
 		// stays in the while loop until the user's input is valid
-		while(year < 2024)
+		while(year < minYear || year > maxYear)
 		{
-			System.out.println("That is not a valid input, please try again.");
-			year = userInput.nextInt();
+			System.out.println("That is not a valid input, please try again."
+					+ " Enter a year between " + minYear + " and " + maxYear + ".");
+			year = readInt();
 		}
 		
 		inputs[5] = String.valueOf(year);
@@ -259,7 +246,54 @@ public class AddSuperBowl {
 	public static void setLocation()
 	{
 		System.out.println("Enter the location the game was played in: ");
-		inputs[6] = userInput.next();
+		inputs[6] = readNonEmptyLine();
+	}
+
+	private static String readYesNo()
+	{
+		String response = userInput.next().trim();
+		while(!(response.equalsIgnoreCase("N")) && !(response.equalsIgnoreCase("Y")))
+		{
+			System.out.println("Enter Y for yes or N for no please.");
+			response = userInput.next().trim();
+		}
+		return response;
+	}
+
+	private static int readInt()
+	{
+		while(!userInput.hasNextInt())
+		{
+			System.out.println("Please enter a valid number.");
+			userInput.next();
+		}
+		return userInput.nextInt();
+	}
+
+	private static String readNonEmptyLine()
+	{
+		userInput.nextLine();
+		String value = userInput.nextLine().trim();
+		while(value.isEmpty())
+		{
+			System.out.println("Input cannot be empty. Please try again.");
+			value = userInput.nextLine().trim();
+		}
+		return value;
+	}
+
+	private static int getMinimumNewYear()
+	{
+		try
+		{
+			String[][] existingData = FileInput.buildDataMatrix(sbInfoFile);
+			int latestYear = Integer.parseInt(existingData[existingData.length - 1][5]);
+			return latestYear + 1;
+		}
+		catch (Exception e)
+		{
+			return Year.now().getValue();
+		}
 	}
 	
 }

--- a/SB_Database_Project/Super_Bowl_Database_Mini_Project/Driver.java
+++ b/SB_Database_Project/Super_Bowl_Database_Mini_Project/Driver.java
@@ -20,7 +20,6 @@ public class Driver {
 	public static void main(String[] args) throws IOException {
 		
 		startMenu.startScreen();
-		AddSuperBowl.writer.close();
 		
 	}
 }

--- a/SB_Database_Project/Super_Bowl_Database_Mini_Project/menuNumber.java
+++ b/SB_Database_Project/Super_Bowl_Database_Mini_Project/menuNumber.java
@@ -9,7 +9,8 @@ import java.util.Scanner;
 
 public class menuNumber {
 	
-	public Scanner keyboard = new Scanner(System.in);
+	private static final Scanner SHARED_KEYBOARD = new Scanner(System.in);
+	public final Scanner keyboard = SHARED_KEYBOARD;
 	private int menuNum;
 	
 	/**
@@ -26,7 +27,15 @@ public class menuNumber {
 	
 	public void setMenuNumber()
 	{
-		this.menuNum = this.keyboard.nextInt();
+		if (this.keyboard.hasNextInt())
+		{
+			this.menuNum = this.keyboard.nextInt();
+		}
+		else
+		{
+			this.keyboard.next();
+			this.menuNum = Integer.MIN_VALUE;
+		}
 	}
 	
 	/**
@@ -50,15 +59,7 @@ public class menuNumber {
 	
 	public boolean checkValidMenuNumber(int menuNumber, int numItems)
 	{
-		if(String.valueOf(menuNumber).compareTo("z") >= 0 || menuNumber < 0 || menuNumber > numItems)
-		{
-			return false;
-		}
-		else
-		{
-			return true;
-		}
-		
+		return menuNumber >= 0 && menuNumber <= numItems;
 	}
 	
 }

--- a/SB_Database_Project/Super_Bowl_Database_Mini_Project/pageThree.java
+++ b/SB_Database_Project/Super_Bowl_Database_Mini_Project/pageThree.java
@@ -3,7 +3,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.InputMismatchException;
 import java.util.List;
-import java.util.Scanner;
 
 /**
  * 
@@ -150,35 +149,30 @@ public class pageThree {
 	{
 		String[] sbTeams = new String[2];
 		String[] sbTeamsInfo;
-		Scanner input = new Scanner(System.in);
 		sbTeamsInfo = FileInput.readFile(sbInfoFile);
 		
 		System.out.println("Which team?");
-		String teamChoice = input.next();
+		String teamChoice = menuNumber.keyboard.next();
 
 		// checks if the user's input is invalid 
-		// and will recursively restarts the method until the user enters a valid input
-		if(containsIgnoreCase(teamsPlayed, teamChoice) == false)
+		// and stays in the loop until the user enters a valid input
+		while(containsIgnoreCase(teamsPlayed, teamChoice) == false)
 		{
 			System.out.println("That does not appear to be an option, please try again.");
-			showTeamSuperBowls();
-		}
-		else
-		{
-			// traverses through the sbTeamsInfo array, 
-			// and prints the Super Bowl's information (if one of the two teams that played 
-			// in the current indexed Super Bowl is the same as the user input)
-			for(int i = 0; i < sbTeamsInfo.length; i++)
-			{
-				sbTeams = superBowls[i][1].split(" vs. ");
-				if(sbTeams[0].equalsIgnoreCase(teamChoice) || sbTeams[1].equalsIgnoreCase(teamChoice))
-				{
-					System.out.println(sbTeamsInfo[i]);
-				}
-			}
+			teamChoice = menuNumber.keyboard.next();
 		}
 
-		input.close();
+		// traverses through the sbTeamsInfo array, 
+		// and prints the Super Bowl's information (if one of the two teams that played 
+		// in the current indexed Super Bowl is the same as the user input)
+		for(int i = 0; i < sbTeamsInfo.length; i++)
+		{
+			sbTeams = superBowls[i][1].split(" vs. ");
+			if(sbTeams[0].equalsIgnoreCase(teamChoice) || sbTeams[1].equalsIgnoreCase(teamChoice))
+			{
+				System.out.println(sbTeamsInfo[i]);
+			}
+		}
 		
 		System.out.println();
 	}

--- a/SB_Database_Project/Super_Bowl_Database_Mini_Project/pageTwo.java
+++ b/SB_Database_Project/Super_Bowl_Database_Mini_Project/pageTwo.java
@@ -85,10 +85,10 @@ public class pageTwo {
 		{
 			System.out.println("Super bowl " + superBowls[num - 1][0] + " was a matchup of " + superBowls[num - 1][1] + " in which the "
 					+ superBowls[num - 1][3] + " won " + superBowls[num - 1][2] + ", and " + superBowls[num - 1][4] + " won the MVP of the game."
-					+ " The game was play in " + superBowls[num - 1][5] + " in " + superBowls[num - 1][6] + ".");
+					+ " The game was played in " + superBowls[num - 1][6] + " in " + superBowls[num - 1][5] + ".");
 			
 			System.out.println();
-			startMenu.runMenuOption();
+			startMenu.startScreen();
 		}
 		
 	}


### PR DESCRIPTION
### Motivation
- Improve robustness of interactive console flows to reduce crashes from malformed input and accidental closing of `System.in`.
- Make file-writing for added records safer and prevent resource misuse or NPEs when no add operation is performed.
- Add basic validation to reduce malformed dataset entries (scores, years, empty fields, team/winner checks).

### Description
- Replace per-instance `Scanner` usage with a shared `Scanner` in `menuNumber` and add safe integer parsing to avoid `InputMismatchException` from stray tokens. (`menuNumber.java`)
- Move file-writing into `AddSuperBowl` using try-with-resources and remove the global writer close from `Driver` to avoid closing resources when not used. (`AddSuperBowl.java`, `Driver.java`)
- Add input helper methods in `AddSuperBowl`: `readYesNo`, `readInt`, `readNonEmptyLine`, and `getMinimumNewYear`, and use `trim()` to normalize text inputs. (`AddSuperBowl.java`)
- Replace fragile binary-search winner validation with explicit case-insensitive comparisons against the two playing teams. (`AddSuperBowl.java`)
- Add dynamic year validation for new entries based on existing dataset and an upper bound tied to the current year. (`AddSuperBowl.java`)
- Stop creating/closing a new `Scanner(System.in)` in `pageThree` and avoid recursive retry by using a loop, preventing accidental closure of `System.in`. (`pageThree.java`)
- Fix `pageTwo` wording/ordering (location/year) and return flow to the main menu. (`pageTwo.java`)

### Testing
- Attempted to compile all Java sources with `javac SB_Database_Project/Super_Bowl_Database_Mini_Project/*.java`, which failed due to missing external JUnit dependency for the repository test file `Super_Bowl_Project_Test.java` (expected).  (failed)
- Compiled all non-test sources into an isolated output directory with `javac -d /tmp/sb-build $(rg --files SB_Database_Project/Super_Bowl_Database_Mini_Project -g '*.java' | rg -v 'Super_Bowl_Project_Test.java')`, which completed successfully. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d015834c832295b12e70fa46a542)